### PR TITLE
Fix #40 Update package.json for node-gcm and apn

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "dependencies": {
     "mongoose": "~3.6.11",
-    "node-gcm": "~0.9.6",
+    "node-gcm": "~0.13.0",
     "lodash": "~1.3.1",
-    "apn": "~1.3.4",
+    "apn": "~1.7.5",
     "express": "~3.2.6",
     "commander": "2.7.1"
   },


### PR DESCRIPTION
So we can use proper Authorization headers in node-gcm and larger apn payloads